### PR TITLE
Topic/fix db port parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VERSION :=`./bin/version`
 IMAGE   := usgseros/lcmap-nemo
-BRANCH     := $(or $(TRAVIS_BRANCH),`git rev-parse --abbrev-ref HEAD | tr / -`)
+BRANCH     := $(or $(TRAVIS_BRANCH),`git rev-parse --abbrev-ref HEAD`)
+BRANCH     := $(shell echo $(BRANCH) | tr / -)
 BUILD_TAG  := $(IMAGE):build
 TAG        := $(shell if [ "$(BRANCH)" = "master" ];\
                          then echo "$(IMAGE):$(VERSION)";\

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -18,10 +18,22 @@
 ;; Starting a REPL will automatically setup and start the system.
 ;;
 
-(try
+(defn start
+  []
+  (try
   (print "starting mount components...")
   (mount/start)
   (print "...ready!")
   (catch RuntimeException ex
     (print "There was a problem automatically setting up and running nemo.")
-    (stacktrace/print-cause-trace ex)))
+    (stacktrace/print-cause-trace ex))))
+
+(defn stop
+  []
+  (try
+    (print "stopping mount components...")
+    (mount/stop)
+    (print "... stopped!")
+    (catch RuntimeException ex
+      (print "There was a problem automatically tearing down nemo.")
+      (stacktrace/print-cause-trace ex))))

--- a/src/lcmap/nemo/config.clj
+++ b/src/lcmap/nemo/config.clj
@@ -38,7 +38,7 @@
   {:db-host                   (-> env :db-host)
    :db-user                   (-> env :db-user)
    :db-pass                   (-> env :db-pass)
-   :db-port                   (-> env :db-port)
+   :db-port                   (-> env :db-port util/numberize)
    :db-keyspace               (-> env :db-keyspace)
    :db-tables                 (-> env :db-tables string->vector)
    :db-connect-timeout-millis (util/numberize
@@ -80,6 +80,7 @@
   "alia shaped configuration"
   [e]
   {:contact-points        (-> e :db-host string->vector)
+   :port                  (:db-port e)
    :credentials           {:user (:db-user e) :password (:db-pass e)}
    :query-options         {:consistency (:consistency e)}
    :load-balancing-policy (:load-balancing-policy e)

--- a/test/lcmap/nemo/config_test.clj
+++ b/test/lcmap/nemo/config_test.clj
@@ -26,13 +26,16 @@
 
 (deftest alia-test
   (testing "testing alia configuration"
-    (let [env {:db-host "host1,host2"
+    (let [env {:db-host "  host1,  host2   "
+               :db-port 9999
                :db-user "user"
                :db-pass "pass"
                :consistency "1"
                :load-balancing-policy "lbp"}
           cfg (alia env)]
+      
       (is (= ["host1" "host2"] (:contact-points cfg)))
+      (is (= 9999 (:port cfg)))
       (is (= {:user "user" :password "pass"} (:credentials cfg)))
       (is (= {:consistency "1"} (:query-options cfg)))
       (is (= "lbp" (:load-balancing-policy cfg))))))


### PR DESCRIPTION
This change enables Nemo to use the :db-port parameter when connecting to Cassandra.